### PR TITLE
Merge Allow setting watchdog timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,4 +20,4 @@ add_executable(
 include(GNUInstallDirs)
 
 # Set the location for executable installation
-install(TARGETS watchdog DESTINATION ${BINDIR})
+install(TARGETS watchdog-manager DESTINATION ${BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Werror -pedantic")
 
 ## set the target name and source
 add_executable(
-    watchdog
+    watchdog-manager
     src/main.c
     src/watchdog.c
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 2.8)
 project(watchdog)
 
 ## set compilation flags
-set(CMAKE_C_FLAGS "-W -Wall -Werror -pedantic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Werror -pedantic")
 
 ## set the target name and source
 add_executable(
@@ -16,3 +16,8 @@ add_executable(
     src/watchdog.c
 )
 
+# Adhere to GNU filesystem layout conventions
+include(GNUInstallDirs)
+
+# Set the location for executable installation
+install(TARGETS watchdog DESTINATION ${BINDIR})

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
-
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
 #include "watchdog.h"
 
 
@@ -13,16 +15,59 @@ static void dump_watchdog_info(struct wdinfo *info)
     printf("Last boot: \t%s\n", (info->bootstatus != 0) ? "Watchdog" : "Power-On-Reset");
 }
 
+static void print_help() {
+    printf("Watchdog interaction tool. Userspace watchdog daemon needs to be stopped.\n");
+    printf("No arguments: Print watchdog info\n");
+    printf("[-h/--help]: Print this help message\n");
+    printf("[-s/--set] T: Set watchdog timer timeout to T seconds.\n\n");
+}
 
-int main()
+int main(int argc, char *argv[])
 {
-    struct wdinfo info;
-    if (wd_getinfo(&info) == -1) {
-        printf("wd_getinfo() failed\n");
-        return -1;
+    if (argc == 1) {
+        struct wdinfo info;
+        if (wd_getinfo(&info) == -1) {
+            printf("wd_getinfo() failed\n");
+            return -1;
+        }
+        dump_watchdog_info(&info);
+    }
+    if (argc >= 2) {
+        if ((strcmp(argv[1], "-s") == 0) || (strcmp(argv[1], "--set") == 0)) {
+            // Convert next argument to integer
+            int timeout;
+            char *endptr;
+            errno = 0;
+            long val;
+            val = strtol(argv[2], &endptr, 0);
+            /* Check for various possible errors */
+            if (errno != 0) {
+                perror("strtol");
+                return -1;
+            }
+            if (endptr == argv[2]) {
+                fprintf(stderr, "No digits were found\n");
+                return -1;
+            }
+            timeout = (int)val;
+
+            printf("Trying to set timeout to %d seconds...\n", timeout);
+
+            // Send argument to function
+            if (wd_settimeout(timeout) < 0) {
+                printf("wd_settimeout() failed\n");
+                return -1;
+            }
+
+            printf("Timeout successfully changed.\n");
+        }
+        else {
+            // Default
+            print_help();
+        }
     }
 
-    dump_watchdog_info(&info);
+
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -9,9 +9,9 @@ static void dump_watchdog_info(struct wdinfo *info)
 {
     printf("Device:\t\t%s\n", WATCHDOG_PATHNAME);
     printf("Identity:\t%s [version %d]\n", info->identity, info->firmware_version);
-    printf("Timeout: \t%d seconds\n", info->timeout);
-    printf("Pre-timeout: \t%d seconds\n", info->pretimeout);
-    printf("Timeleft: \t%d seconds\n", info->timeleft);
+    if (info->timeout != DATA_ERROR) printf("Timeout: \t%d seconds\n", info->timeout);
+    if (info->pretimeout != DATA_ERROR) printf("Pre-timeout: \t%d seconds\n", info->pretimeout);
+    if (info->timeleft != DATA_ERROR) printf("Timeleft: \t%d seconds\n", info->timeleft);
     printf("Last boot: \t%s\n", (info->bootstatus != 0) ? "Watchdog" : "Power-On-Reset");
 }
 

--- a/src/watchdog.c
+++ b/src/watchdog.c
@@ -67,11 +67,25 @@ int wd_getinfo(struct wdinfo *info)
      * that we intend to close/stop the watchdog. Otherwise, debug message
      * 'Watchdog timer closed unexpectedly' will be printed in dmesg
      */
-    if (write(wfd, "V", 1) != 1)
+    if (write(wfd, "V", 1) != 1) {
         print_err("%s", "Watchdog closed unexpectedly\n");
+        return -1;
+    }
 
     close(wfd);
 
     return 0;
 }
 
+int wd_settimeout(int timeout) {
+    int wfd = _get_watchdog_fd();
+    if (wfd == -1)
+        return -1;
+
+    if (ioctl(wfd, WDIOC_SETTIMEOUT, &timeout) == -1) {
+        print_err("Error: Could not set timeout: %s\n", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/watchdog.c
+++ b/src/watchdog.c
@@ -37,13 +37,22 @@ static int _fill_watchdog_info(int wfd, struct wdinfo *info)
 
     /* Get watchdog current timeout */
     if (ioctl(wfd, WDIOC_GETTIMEOUT, &(info->timeout)) == -1)
+    {
+        info->timeout = DATA_ERROR;
         print_err("Error: Cannot read watchdog timeout: %s\n", strerror(errno));
+    }
     /* Get watchdog current pre-timeout */
     if (ioctl(wfd, WDIOC_GETPRETIMEOUT, &(info->pretimeout)) == -1)
+    {
+        info->pretimeout = DATA_ERROR;
         print_err("Error: Cannot read watchdog pretimeout: %s\n", strerror(errno));
+    }
     /* Get watchdog current timeleft */
     if (ioctl(wfd, WDIOC_GETTIMELEFT, &(info->timeleft)) == -1)
+    {
+        info->timeleft = DATA_ERROR;
         print_err("Error: Cannot read watchdog timeleft: %s\n", strerror(errno));
+    }
     /* Get watchdog current bootstatus */
     if (ioctl(wfd, WDIOC_GETBOOTSTATUS, &(info->bootstatus)) == -1)
         print_err("Error: Cannot read watchdog boot status: %s\n", strerror(errno));

--- a/src/watchdog.h
+++ b/src/watchdog.h
@@ -76,7 +76,17 @@ struct wdinfo {
  * \return -1 on error, 0 on success
  */
 int wd_getinfo(struct wdinfo *info);
-
+/*!
+ * \brief Set watchdog timeout
+ *
+ * Change the watchdog timeout value
+ * default path: "/dev/watchdog"
+ *
+ * \param   timeout    Watchdog timeout in seconds
+ *
+ * \return -1 on error, 0 on success
+ */
+int wd_settimeout(int timeout);
 
 #ifdef __cplusplus
 }

--- a/src/watchdog.h
+++ b/src/watchdog.h
@@ -53,6 +53,8 @@ extern "C"
 
 #define WATCHDOG_PATHNAME "/dev/watchdog"
 
+#define DATA_ERROR -100
+
 
 struct wdinfo {
     uint32_t options;           /* Options the card/driver support */


### PR DESCRIPTION
Changes added by this merge request:

* Fix CMakeLists.txt to enable Yocto compilation
* Rename binary to watchdog manager - this avoids naming conflicts with systemd watchdog binary
* Do not print values in systems where they are not accessible